### PR TITLE
Add screen share polyfill.

### DIFF
--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -3,7 +3,14 @@ import { join } from "path";
 import { format } from "url";
 
 // Packages
-import { BrowserWindow, app, ipcMain, IpcMainEvent } from "electron";
+import {
+  BrowserWindow,
+  app,
+  ipcMain,
+  IpcMainEvent,
+  Menu,
+  desktopCapturer,
+} from "electron";
 import isDev from "electron-is-dev";
 import prepareNext from "electron-next";
 
@@ -29,6 +36,7 @@ app.on("ready", async () => {
         slashes: true,
       });
 
+  // mainWindow.webContents.openDevTools();
   mainWindow.loadURL(url);
 });
 
@@ -39,4 +47,28 @@ app.on("window-all-closed", app.quit);
 ipcMain.on("message", (event: IpcMainEvent, message: any) => {
   console.log(message);
   setTimeout(() => event.sender.send("message", "hi from electron"), 500);
+});
+
+// display a menu for the user to select videoconf screen share sources
+ipcMain.on("show-screen-share-selector", async (event: IpcMainEvent) => {
+  const inputSources = await desktopCapturer.getSources({
+    types: ["window", "screen"],
+  });
+
+  try {
+    const selectedSourceId = await new Promise<string>((resolve, reject) => {
+      const videoOptionsMenu = Menu.buildFromTemplate(
+        inputSources.map((source) => ({
+          label: source.name,
+          click: () => resolve(source.id),
+        })),
+      );
+
+      // callback gets called after menu closes and is only fast enough if no selection was made
+      videoOptionsMenu.popup({ callback: reject });
+    });
+    event.reply("show-screen-share-selector", true, selectedSourceId);
+  } catch (e) {
+    event.reply("show-screen-share-selector", false);
+  }
 });

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -51,11 +51,11 @@ ipcMain.on("message", (event: IpcMainEvent, message: any) => {
 
 // display a menu for the user to select videoconf screen share sources
 ipcMain.on("show-screen-share-selector", async (event: IpcMainEvent) => {
-  const inputSources = await desktopCapturer.getSources({
-    types: ["window", "screen"],
-  });
-
   try {
+    const inputSources = await desktopCapturer.getSources({
+      types: ["window", "screen"],
+    });
+
     const selectedSourceId = await new Promise<string>((resolve, reject) => {
       const videoOptionsMenu = Menu.buildFromTemplate(
         inputSources.map((source) => ({

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -1,17 +1,49 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { ipcRenderer, IpcRenderer } from 'electron'
+import { ipcRenderer, IpcRenderer } from "electron";
 
 declare global {
   namespace NodeJS {
     interface Global {
-      ipcRenderer: IpcRenderer
+      ipcRenderer: IpcRenderer;
     }
   }
 }
 
 // Since we disabled nodeIntegration we can reintroduce
 // needed node functionality here
-process.once('loaded', () => {
-  global.ipcRenderer = ipcRenderer
-})
+process.once("loaded", () => {
+  global.ipcRenderer = ipcRenderer;
+});
+
+// Electron does not include a screen picker for screensharing. This addresses that. Also,
+// SignalWire calls getDisplayMedia() for screensharing, but getUserMedia() is what should be called.
+window.navigator.mediaDevices.getDisplayMedia = async () => {
+  // TODO: Check permissions with systemPreferences.getMediaAccessStatus("screen" | "microphone" | "camera").
+  // TODO: Request "screen" permissions from systemPreferences.
+  // TODO: Implement better UI than simple Electron.Menu.
+  const selectedSourceId = await new Promise<string>((resolve, reject) => {
+    ipcRenderer.once(
+      "show-screen-share-selector",
+      (_event, isSuccess, sourceId) => {
+        if (!isSuccess) reject();
+        resolve(sourceId);
+      },
+    );
+    ipcRenderer.send("show-screen-share-selector");
+  });
+
+  const constraints = {
+    audio: false,
+    video: {
+      mandatory: {
+        chromeMediaSource: "desktop",
+        chromeMediaSourceId: selectedSourceId,
+      },
+    },
+  };
+
+  return window.navigator.mediaDevices.getUserMedia(
+    constraints as MediaStreamConstraints,
+  );
+};


### PR DESCRIPTION
This proves out the concept. There will be more work required, including, but not limited to:

- Check permissions with `systemPreferences.getMediaAccessStatus("screen" | "microphone" | "camera")`
- Request "screen" permissions from systemPreferences
- Implement better UI than simple `Electron.Menu`

But that's for the next phase.

I learned a lot about Electron doing this!